### PR TITLE
Allow SSH forwarding so ssh commands on the guest can use host keys

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -11,6 +11,7 @@ Vagrant.configure("2") do |config|
   config.vm.hostname = vconfig['vagrant_hostname']
   config.vm.network :private_network, ip: vconfig['vagrant_ip']
   config.ssh.insert_key = false
+  config.ssh.forward_agent = true
 
   config.vm.box = "geerlingguy/ubuntu1204"
 


### PR DESCRIPTION
Allow SSH forwarding so ssh commands on the guest can use the host identity.

This is mainly so acquia drush aliases can work from the guest.
You need to set ForwardAgent yes in ~/.ssh/config however if this is not set it will be ignored.
